### PR TITLE
 fix path for photos api

### DIFF
--- a/api/v1/photo.go
+++ b/api/v1/photo.go
@@ -77,7 +77,7 @@ func (v1 *V1Client) GetPhoto(uuid string) (*Photo, error) {
 	if uuid == "" {
 		return nil, fmt.Errorf("missing uuid for GetPhoto [GET /api/v1/photos/:uuid]")
 	}
-	resp, err := v1.GET("photos/%s", uuid)
+	resp, err := v1.GET("api/v1/photos/%s", uuid)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get photo uuid=%s with error: %v", uuid, err)
 	}


### PR DESCRIPTION
```
➜  examples git:(photos-api-json) ✗ go run photo.go common.go2021-02-03T23:14:52-08:00 [✿]  Login Success!
http://localhost:8080/api/v1/photos/\[pqnzsew2k506y94u\]
{ID:0,DocumentID:pqnzsew2k506y94u,TakenAt:0001-01-01T00:00:00Z,TakenAtLocal:0001-01-01T00:00:00Z,TakenSrc:,UID:,Type:,TypeSrc:,Title:,TitleSrc:,Description:,DescriptionSrc:,Path:,Name:,OriginalName:,Stack:0,Favorite:false,Private:false,Scan:false,Panorama:false,TimeZone:,PlaceID:,PlaceSrc:,CellID:,CellAccuracy:0,Altitude:0,Lat:0,Lng:0,Country:,Year:0,Month:0,Day:0,Iso:0,Exposure:,FNumber:0,FocalLength:0,Quality:0,Resolution:0,Color:0,CameraID:0,CameraSerial:,CameraSrc:,LensID:0,CreatedAt:0001-01-01T00:00:00Z,UpdatedAt:0001-01-01T00:00:00Z,EditedAt:null,CheckedAt:null,DeletedAt:null}
```